### PR TITLE
Update to 1.20.6 & add german translations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.2-SNAPSHOT'
+    id 'fabric-loom' version '1.6-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -33,7 +33,7 @@ processResources {
     }
 }
 
-def targetJavaVersion = 17
+def targetJavaVersion = 21
 tasks.withType(JavaCompile).configureEach {
     // ensure that the encoding is set to UTF-8, no matter what the system default is
     // this fixes some edge cases with special characters not displaying correctly
@@ -51,6 +51,8 @@ java {
         toolchain.languageVersion = JavaLanguageVersion.of(targetJavaVersion)
     }
     archivesBaseName = project.archives_base_name
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
     // Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
     // if it is present.
     // If you remove this line, sources will not be generated.
@@ -66,7 +68,8 @@ jar {
 // configure the maven publication
 publishing {
     publications {
-        mavenJava(MavenPublication) {
+        create("mavenJava", MavenPublication) {
+            artifactId = project.archives_base_name
             from components.java
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20
-yarn_mappings=1.20+build.1
-loader_version=0.14.21
+minecraft_version=1.20.6
+yarn_mappings=1.20.6+build.1
+loader_version=0.15.11
 # Mod Properties
-mod_version=1.1.1R
+mod_version=1.1.2R
 maven_group=RinF
 archives_base_name=autoclicker-rinf
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.83.0+1.20
+fabric_version=0.97.8+1.20.6

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/rinf/autoclickerrinf/client/gui/ACFHud.java
+++ b/src/main/java/rinf/autoclickerrinf/client/gui/ACFHud.java
@@ -27,16 +27,23 @@ public class ACFHud {
         this.tickDelta = tickDelta;
 
         Window window = MinecraftClient.getInstance().getWindow();
-        int hudWight = window.getScaledWidth();
-        int hudHeight = window.getScaledHeight();
+        int x = window.getScaledWidth() / 2;
+        int y = window.getScaledHeight() - 54;
 
-        jobIndicator = new IconWidget((hudWight / 2) - 8, hudHeight - 54, 16, 16, Identifier.of("minecraft", "textures/item/barrier.png"));
-        if (ClickController.lClickerActive) lIndicator = new IconWidget((hudWight / 2) - 14, hudHeight - 54, 4, 4, Identifier.of("minecraft", "textures/block/white_shulker_box.png"));
-        else lIndicator = new IconWidget((hudWight / 2) - 14, hudHeight - 54, 4, 4, Identifier.of("minecraft", "textures/block/gray_shulker_box.png"));
-        if (ClickController.rClickerActive) rIndicator = new IconWidget((hudWight / 2) + 10, hudHeight - 54, 4, 4, Identifier.of("minecraft", "textures/block/white_shulker_box.png"));
-        else rIndicator = new IconWidget((hudWight / 2) + 10, hudHeight - 54, 4, 4, Identifier.of("minecraft", "textures/block/gray_shulker_box.png"));
+        jobIndicator = IconWidget.create(16, 16,
+                Identifier.of("minecraft", "textures/item/barrier.png"), 16, 16);
+        lIndicator = IconWidget.create(4, 4,
+                Identifier.of("minecraft",
+                        ClickController.lClickerActive ? "textures/block/white_shulker_box.png" : "textures/block/gray_shulker_box.png"),
+                16, 16);
+        rIndicator = IconWidget.create(4, 4,
+                Identifier.of("minecraft",
+                        ClickController.rClickerActive ? "textures/block/white_shulker_box.png" : "textures/block/gray_shulker_box.png"),
+                16, 16);
 
-
+        jobIndicator.setPosition(x - 8, y);
+        lIndicator.setPosition(x - 14, y);
+        rIndicator.setPosition(x + 10, y);
         drawables.add(jobIndicator);
         drawables.add(lIndicator);
         drawables.add(rIndicator);

--- a/src/main/java/rinf/autoclickerrinf/client/gui/ACFMenuScreen.java
+++ b/src/main/java/rinf/autoclickerrinf/client/gui/ACFMenuScreen.java
@@ -5,7 +5,9 @@ import net.fabricmc.api.Environment;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.widget.*;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.CheckboxWidget;
+import net.minecraft.client.gui.widget.TextWidget;
 import net.minecraft.text.Text;
 import rinf.autoclickerrinf.client.AutoclickerRinfClient;
 import rinf.autoclickerrinf.client.ClickController;
@@ -43,8 +45,15 @@ public class ACFMenuScreen extends Screen {
         rTitleTextWidget = new TextWidget(148, 7, 110, 20, Text.translatable("autoclicker-rinf.rightmousebutton"), textRenderer);
         rTitleTextWidget.setTextColor(0xffff00);
 
-        lActiveCheckboxWidget = new CheckboxWidget(118, 6, 20, 20, Text.empty(), ClickController.lClickerActive);
-        rActiveCheckboxWidget = new CheckboxWidget(258, 6, 20, 20, Text.empty(), ClickController.rClickerActive);
+        lActiveCheckboxWidget = CheckboxWidget.builder(Text.empty(), textRenderer)
+                .pos(118, 6)
+                .checked(ClickController.lClickerActive)
+                .build();
+
+        rActiveCheckboxWidget = CheckboxWidget.builder(Text.empty(), textRenderer)
+                .pos(258, 6)
+                .checked(ClickController.rClickerActive)
+                .build();
 
         lClickDelayTextFieldWidget = new ClickDelayTextFieldWidget(textRenderer, 10, 30, 110, 20, Text.literal("0"));
         lClickDelayTextFieldWidget.visible = false;
@@ -52,7 +61,8 @@ public class ACFMenuScreen extends Screen {
         rClickDelayTextFieldWidget.visible = false;
 
         lClickDelaySaveButtonWidget = ButtonWidget.builder(Text.literal("OK"), button -> {
-            if (!lClickDelayTextFieldWidget.getText().equals("")) ClickController.lClickDelayInt = convertStringToInt(lClickDelayTextFieldWidget.getText());
+            if (!lClickDelayTextFieldWidget.getText().isEmpty())
+                ClickController.lClickDelayInt = convertStringToInt(lClickDelayTextFieldWidget.getText());
             lClickDelayButtonWidget.setMessage(Text.translatable("autoclicker-rinf.clickdelay", ClickController.lClickDelayInt));
             lClickDelayTextFieldWidget.setText("");
 
@@ -63,7 +73,8 @@ public class ACFMenuScreen extends Screen {
         }).dimensions(120, 30, 20, 20).build();
         lClickDelaySaveButtonWidget.visible = false;
         rClickDelaySaveButtonWidget = ButtonWidget.builder(Text.literal("OK"), button -> {
-            if (!rClickDelayTextFieldWidget.getText().equals("")) ClickController.rClickDelayInt = convertStringToInt(rClickDelayTextFieldWidget.getText());
+            if (!rClickDelayTextFieldWidget.getText().isEmpty())
+                ClickController.rClickDelayInt = convertStringToInt(rClickDelayTextFieldWidget.getText());
             rClickDelayButtonWidget.setMessage(Text.translatable("autoclicker-rinf.clickdelay", ClickController.rClickDelayInt));
             rClickDelayTextFieldWidget.setText("");
 
@@ -110,7 +121,7 @@ public class ACFMenuScreen extends Screen {
             lCooldownAttackModeButtonWidget.setMessage(Text.translatable("autoclicker-rinf.attackcooldownmode", ClickController.lCooldownAttackMode));
         }).dimensions(10, 102, 130, 20).build();
 
-        doneButtonWidget = ButtonWidget.builder(Text.translatable("gui.done"), button -> this.close() ).dimensions(10, height - 30, 50, 20).build();
+        doneButtonWidget = ButtonWidget.builder(Text.translatable("gui.done"), button -> this.close()).dimensions(10, height - 30, 50, 20).build();
 
 
         if (AutoclickerRinfClient.isME && !MinecraftClient.getInstance().isIntegratedServerRunning()) {
@@ -144,7 +155,7 @@ public class ACFMenuScreen extends Screen {
 
     @Override
     public void render(DrawContext drawContext, int mouseX, int mouseY, float delta) {
-        this.renderBackground(drawContext);
+        this.renderBackground(drawContext, mouseX, mouseY, delta);
         super.render(drawContext, mouseX, mouseY, delta);
     }
 
@@ -160,8 +171,7 @@ public class ACFMenuScreen extends Screen {
         int value = 0;
         try {
             value = Integer.parseInt(str);
-        }
-        catch (NumberFormatException e) {
+        } catch (NumberFormatException e) {
             System.out.println("Convert String To Int Exception: " + e);
         }
         return value;

--- a/src/main/resources/assets/autoclicker-rinf/lang/de_de.json
+++ b/src/main/resources/assets/autoclicker-rinf/lang/de_de.json
@@ -1,0 +1,12 @@
+{
+  "category.rinf-mods.general": "RinF Mod-Einstellungen",
+  "autoclicker-rinf.leftmousebutton": "Linke Maustaste",
+  "autoclicker-rinf.rightmousebutton": "Rechte Maustaste",
+  "key.autoclicker-rinf.openacfm": "Autoklicker-Menü öffnen",
+  "key.autoclicker-rinf.toggleacf": "Autoklicker umschalten",
+  "autoclicker-rinf.clickdelay": "Verzögerung in Ticks: %d",
+  "autoclicker-rinf.settingmenul": "Einstellungen",
+  "autoclicker-rinf.targetentitymode": "Ziel-Entität-Modus: %d",
+  "autoclicker-rinf.attackcooldownmode": "Cooldown-Angriffsmodus: %d",
+  "autoclicker-rinf.holdmode": "Halten-Modus: %d"
+}

--- a/src/main/resources/autoclicker-rinf.mixins.json
+++ b/src/main/resources/autoclicker-rinf.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "rinf.autoclickerrinf.mixin",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
   ],
   "client": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -25,8 +25,8 @@
     "autoclicker-rinf.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.21",
+    "fabricloader": ">=0.15.11",
     "fabric": "*",
-    "minecraft": "1.20"
+    "minecraft": ">=1.20.5"
   }
 }


### PR DESCRIPTION
I updated the mod to 1.20.6 and while I was at it, also added german translations.

Since Minecraft requires java 21 for 1.20.5+, you're going to have to change your project SDK to a java 21 one to successfully build.